### PR TITLE
Improve landing page aesthetics

### DIFF
--- a/frontend/app/(marketing)/landing/page.tsx
+++ b/frontend/app/(marketing)/landing/page.tsx
@@ -20,11 +20,11 @@ import { cn } from "@/lib/utils";
 
 /* ───────── helpers & variants ───────── */
 const fadeUp = {
-  hidden: { opacity: 0, y: 24 },
+  hidden: { opacity: 0, y: 30 },
   visible: (i = 0) => ({
     opacity: 1,
     y: 0,
-    transition: { delay: i * 0.08, duration: 0.6 },
+    transition: { delay: i * 0.12, duration: 0.8, ease: "easeOut" },
   }),
 };
 
@@ -357,7 +357,10 @@ export default function LandingPage() {
         <div className="mt-8 flex flex-wrap justify-center gap-4">
           <Link
             href="/signup"
-            className={cn(buttonVariants({ variant: "default", size: "lg" }))}
+            className={cn(
+              buttonVariants({ variant: "default", size: "lg" }),
+              "bg-white text-[--accent-primary] hover:bg-white/90 active:bg-white/80"
+            )}
           >
             Sign up free
           </Link>


### PR DESCRIPTION
## Summary
- smooth out fade-in animations
- tweak final signup button color to stand out better

## Testing
- `npm run lint`
- `npm run type-check`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685a1932c394833191e1d5dc81e9a209