### PR TITLE
Improve intern profile page design

### DIFF
--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -56,7 +56,7 @@ export default function InternProfilePage() {
   return (
     <main className="min-h-screen bg-gray-50/60">
       {/* hero */}
-      <section className="relative flex h-56 items-center justify-center overflow-hidden bg-gradient-to-br from-[--accent-primary] to-[--accent] px-6 text-center text-black">
+      <section className="relative flex h-64 items-center justify-center overflow-hidden bg-gradient-to-br from-[--accent-primary] to-[--accent] px-6 text-center text-black sm:h-72">
         {/* animated blobs */}
         <motion.div
           className="pointer-events-none absolute -left-16 -top-16 size-44 rounded-full bg-black/10 blur-3xl"
@@ -69,7 +69,7 @@ export default function InternProfilePage() {
           transition={{ duration: 9, repeat: Infinity, ease: "easeInOut" }}
         />
         <div className="relative z-10 space-y-3">
-          <h1 className="text-4xl font-semibold tracking-tight">My&nbsp;Profile</h1>
+          <h1 className="text-5xl font-bold tracking-tight sm:text-6xl">My&nbsp;Profile</h1>
           <p className="text-sm opacity-90">How employers will see you on&nbsp;Pipeline</p>
           <motion.div whileTap={{ scale: 0.94 }}>
             <Link
@@ -92,16 +92,16 @@ export default function InternProfilePage() {
           initial={{ opacity: 0, y: 24 }}
           animate={{ opacity: 1, y: 0, transition: { duration: 0.45, ease: [0.16, 1, 0.3, 1] } }}
         >
-          <Card className="rounded-3xl shadow-lg transition-shadow hover:shadow-xl">
-            <CardHeader className="flex flex-col items-center gap-2 rounded-t-3xl border-b bg-gradient-to-r from-background to-muted/50 p-8 text-center">
+          <Card className="rounded-3xl bg-background/80 shadow-lg backdrop-blur-lg transition-shadow hover:shadow-2xl">
+            <CardHeader className="flex flex-col items-center gap-3 rounded-t-3xl border-b bg-gradient-to-r from-background to-muted/50 p-8 text-center">
               {/* avatar */}
-              <div className="flex size-24 items-center justify-center overflow-hidden rounded-full bg-muted/50 shadow-inner">
+              <div className="flex size-28 items-center justify-center overflow-hidden rounded-full bg-muted/50 shadow-xl ring-4 ring-white">
                 {profile.avatar_url ? (
                   <Image
                     src={profile.avatar_url}
                     alt="User Avatar"
-                    width={96}
-                    height={96}
+                    width={112}
+                    height={112}
                     className="object-cover"
                   />
                 ) : (
@@ -119,136 +119,142 @@ export default function InternProfilePage() {
               )}
             </CardHeader>
 
-            <CardContent className="space-y-10 p-8">
-              {/* About */}
-              <section>
-                <h2 className="mb-2 text-lg font-medium text-[--accent-primary]">
-                  About
-                </h2>
-                <p className="whitespace-pre-wrap leading-relaxed">
-                  {profile.bio || "—"}
-                </p>
-              </section>
+            <CardContent className="p-8">
+              <div className="grid gap-10 md:grid-cols-2">
+                <div className="space-y-10">
+                  {/* About */}
+                  <section>
+                    <h2 className="mb-2 text-lg font-medium text-[--accent-primary]">
+                      About
+                    </h2>
+                    <p className="whitespace-pre-wrap leading-relaxed">
+                      {profile.bio || "—"}
+                    </p>
+                  </section>
 
-              {/* Availability */}
-              <section>
-                <h2 className="mb-2 text-lg font-medium text-[--accent-primary]">
-                  Availability
-                </h2>
-                {profile.availability ? (
-                  <p className="flex flex-wrap items-center gap-2 text-sm">
-                    <Clock className="h-4 w-4" />
-                    <span className="capitalize">
-                      {profile.availability.status.toLowerCase()}
-                    </span>
-                    {profile.availability.status === "FROM_DATE" &&
-                      profile.availability.earliest_start && (
-                        <span>{`from ${profile.availability.earliest_start}`}</span>
-                      )}
-                    {profile.availability.hours_per_week && (
-                      <span>
-                        • {profile.availability.hours_per_week} hrs&nbsp;/&nbsp;wk
-                      </span>
+                  {/* Availability */}
+                  <section>
+                    <h2 className="mb-2 text-lg font-medium text-[--accent-primary]">
+                      Availability
+                    </h2>
+                    {profile.availability ? (
+                      <p className="flex flex-wrap items-center gap-2 text-sm">
+                        <Clock className="h-4 w-4" />
+                        <span className="capitalize">
+                          {profile.availability.status.toLowerCase()}
+                        </span>
+                        {profile.availability.status === "FROM_DATE" &&
+                          profile.availability.earliest_start && (
+                            <span>{`from ${profile.availability.earliest_start}`}</span>
+                          )}
+                        {profile.availability.hours_per_week && (
+                          <span>
+                            • {profile.availability.hours_per_week} hrs&nbsp;/&nbsp;wk
+                          </span>
+                        )}
+                        {profile.availability.remote_ok && <span>• remote OK</span>}
+                        {profile.availability.onsite_ok && <span>• onsite OK</span>}
+                      </p>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">—</p>
                     )}
-                    {profile.availability.remote_ok && <span>• remote OK</span>}
-                    {profile.availability.onsite_ok && <span>• onsite OK</span>}
-                  </p>
-                ) : (
-                  <p className="text-sm text-muted-foreground">—</p>
-                )}
-              </section>
+                  </section>
 
-              {/* Resume */}
-              <section>
-                <h2 className="mb-2 text-lg font-medium text-[--accent-primary]">
-                  Resume
-                </h2>
-                {profile.resume ? (
-                  <a
-                    href={profile.resume}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-sm font-medium text-[--accent-primary] hover:underline"
-                  >
-                    <Download className="h-4 w-4" />
-                    <span>Download&nbsp;Resume</span>
-                  </a>
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    No resume uploaded.
-                  </p>
-                )}
-              </section>
-
-              {/* Skills */}
-              <section>
-                <h2 className="mb-2 text-lg font-medium text-[--accent-primary]">
-                  Skills
-                </h2>
-                {profile.skills.length ? (
-                  <div className="flex flex-wrap gap-2">
-                    {profile.skills.map((s: Skill) => (
-                      <motion.div
-                        key={s.id}
-                        whileHover={{ scale: 1.08 }}
-                        whileFocus={{ scale: 1.08 }}
+                  {/* Resume */}
+                  <section>
+                    <h2 className="mb-2 text-lg font-medium text-[--accent-primary]">
+                      Resume
+                    </h2>
+                    {profile.resume ? (
+                      <a
+                        href={profile.resume}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-sm font-medium text-[--accent-primary] hover:underline"
                       >
-                        <Badge variant="secondary" className="text-sm shadow-sm">
-                          {s.name}
-                        </Badge>
-                      </motion.div>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    No skills added yet.
-                  </p>
-                )}
-              </section>
+                        <Download className="h-4 w-4" />
+                        <span>Download&nbsp;Resume</span>
+                      </a>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        No resume uploaded.
+                      </p>
+                    )}
+                  </section>
+                </div>
 
-              {/* Education */}
-              <section>
-                <h2 className="mb-2 text-lg font-medium text-[--accent-primary]">
-                  Education
-                </h2>
-                {profile.educations.length ? (
-                  <ul className="space-y-6">
-                    {profile.educations.map((edu: Education) => (
-                      <motion.li
-                        key={edu.id}
-                        whileHover={{ y: -2, boxShadow: "0 6px 18px rgba(0,0,0,0.08)" }}
-                        className="rounded-xl border bg-background/60 p-5 transition"
-                      >
-                        <div className="flex items-start gap-4">
-                          <GraduationCap className="mt-1 h-6 w-6 shrink-0 text-[--accent-primary]" />
-                          <div className="space-y-1">
-                            <p className="text-base font-medium">{edu.institution}</p>
-                            <p className="text-sm text-muted-foreground">
-                              {[edu.degree, edu.field_of_study].filter(Boolean).join(", ") || "—"}
-                            </p>
-                            <p className="text-xs text-muted-foreground">
-                              {edu.start_date} – {edu.end_date ?? "present"}
-                              {edu.gpa && ` • GPA ${edu.gpa}`}
-                            </p>
-                            {edu.description && (
-                              <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed">
-                                {edu.description}
-                              </p>
-                            )}
-                          </div>
-                        </div>
-                      </motion.li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    No education records yet.
-                  </p>
-                )}
-              </section>
+                <div className="space-y-10">
+                  {/* Skills */}
+                  <section>
+                    <h2 className="mb-2 text-lg font-medium text-[--accent-primary]">
+                      Skills
+                    </h2>
+                    {profile.skills.length ? (
+                      <div className="flex flex-wrap gap-2">
+                        {profile.skills.map((s: Skill) => (
+                          <motion.div
+                            key={s.id}
+                            whileHover={{ scale: 1.08 }}
+                            whileFocus={{ scale: 1.08 }}
+                          >
+                            <Badge variant="secondary" className="text-sm shadow-sm">
+                              {s.name}
+                            </Badge>
+                          </motion.div>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        No skills added yet.
+                      </p>
+                    )}
+                  </section>
+
+                  {/* Education */}
+                  <section>
+                    <h2 className="mb-2 text-lg font-medium text-[--accent-primary]">
+                      Education
+                    </h2>
+                    {profile.educations.length ? (
+                      <ul className="space-y-6">
+                        {profile.educations.map((edu: Education) => (
+                          <motion.li
+                            key={edu.id}
+                            whileHover={{ y: -2, boxShadow: "0 6px 18px rgba(0,0,0,0.08)" }}
+                            className="rounded-xl border bg-background/60 p-5 transition"
+                          >
+                            <div className="flex items-start gap-4">
+                              <GraduationCap className="mt-1 h-6 w-6 shrink-0 text-[--accent-primary]" />
+                              <div className="space-y-1">
+                                <p className="text-base font-medium">{edu.institution}</p>
+                                <p className="text-sm text-muted-foreground">
+                                  {[edu.degree, edu.field_of_study].filter(Boolean).join(", ") || "—"}
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                  {edu.start_date} – {edu.end_date ?? "present"}
+                                  {edu.gpa && ` • GPA ${edu.gpa}`}
+                                </p>
+                                {edu.description && (
+                                  <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed">
+                                    {edu.description}
+                                  </p>
+                                )}
+                              </div>
+                            </div>
+                          </motion.li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        No education records yet.
+                      </p>
+                    )}
+                  </section>
+                </div>
+              </div>
 
               {/* Updated */}
-              <p className="text-right text-xs text-muted-foreground">
+              <p className="mt-8 text-right text-xs text-muted-foreground">
                 Last updated {new Date(profile.updated_at).toLocaleString()}
               </p>
             </CardContent>


### PR DESCRIPTION
## Summary
- restyle the intern profile page with modern aesthetics
- add backdrop blur and a grid layout for better readability

## Testing
- `npm run lint`
- `npm run type-check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a197d3cbc83319961e284dff0701c