### PR TITLE
Fix final CTA button contrast

### DIFF
--- a/frontend/app/(marketing)/landing/page.tsx
+++ b/frontend/app/(marketing)/landing/page.tsx
@@ -357,10 +357,7 @@ export default function LandingPage() {
         <div className="mt-8 flex flex-wrap justify-center gap-4">
           <Link
             href="/signup"
-            className={cn(
-              buttonVariants({ variant: "default", size: "lg" }),
-              "bg-white text-[--accent-primary] hover:bg-white/90 active:bg-white/80"
-            )}
+            className={cn(buttonVariants({ variant: "default", size: "lg" }))}
           >
             Sign up free
           </Link>


### PR DESCRIPTION
## Summary
- improve readability of the "Sign up free" button in the landing page CTA

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a1c4e06d88331bbb47d0dd3243a4a