### PR TITLE
Fix landing page sign-up button visibility

### DIFF
--- a/frontend/app/(marketing)/landing/page.tsx
+++ b/frontend/app/(marketing)/landing/page.tsx
@@ -177,7 +177,10 @@ export default function LandingPage() {
         <div className="mt-8 flex flex-wrap justify-center gap-4">
           <Link
             href="/signup"
-            className={cn(buttonVariants({ variant: "default", size: "lg" }))}
+            className={cn(
+              buttonVariants({ variant: "default", size: "lg" }),
+              "bg-white text-[--accent-primary] hover:bg-white/90 active:bg-white/80"
+            )}
           >
             Sign up
           </Link>
@@ -241,7 +244,10 @@ export default function LandingPage() {
           <div className="mt-8 flex flex-wrap justify-center gap-4">
             <Link
               href="/signup"
-              className={cn(buttonVariants({ variant: "default", size: "lg" }))}
+              className={cn(
+                buttonVariants({ variant: "default", size: "lg" }),
+                "bg-white text-[--accent-primary] hover:bg-white/90 active:bg-white/80"
+              )}
             >
               Create account
             </Link>


### PR DESCRIPTION
## Summary
- adjust "Sign up" and "Create account" buttons on the landing page so they use a white background with accent colored text

## Testing
- `pytest -q`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1c04c92083319f86176294e62441