### PR TITLE
Fix timeline step colors on landing page

### DIFF
--- a/frontend/app/(marketing)/landing/page.tsx
+++ b/frontend/app/(marketing)/landing/page.tsx
@@ -305,7 +305,8 @@ export default function LandingPage() {
               variants={fadeUp}
               className="flex-1 px-6"
             >
-              <div className="mx-auto grid h-12 w-12 place-items-center rounded-full bg-[--accent-primary] text-white shadow">
+              {/* accent variable wasn't applied in some builds, so use explicit color */}
+              <div className="mx-auto grid h-12 w-12 place-items-center rounded-full bg-[#06b6d4] text-white shadow">
                 {step}
               </div>
               <h3 className="mt-4 text-lg font-semibold">{title}</h3>


### PR DESCRIPTION
## Summary
- ensure timeline steps use an explicit accent color so text remains visible

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_685a1cd7a7b08331abdcc7f9603f2c33