### PR TITLE
Sync employer signup button style

### DIFF
--- a/frontend/app/(marketing)/landing/page.tsx
+++ b/frontend/app/(marketing)/landing/page.tsx
@@ -245,8 +245,8 @@ export default function LandingPage() {
             <Link
               href="/signup"
               className={cn(
-                buttonVariants({ variant: "default", size: "lg" }),
-                "bg-white text-[--accent-primary] hover:bg-white/90 active:bg-white/80"
+                buttonVariants({ variant: "ghost", size: "lg" }),
+                "border border-[--accent-primary] bg-[--accent-primary] text-white hover:bg-[--accent-primary]/90 active:bg-[--accent-primary]/80"
               )}
             >
               Create account


### PR DESCRIPTION
## Summary
- unify the 'Create account' button style with the student 'Sign up' button on the landing page

## Testing
- `pytest -q`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_685a27fc0d30833183199a1a684512a2