### PR TITLE
Fix login auth cache

### DIFF
--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -1,50 +1,20 @@
 "use client";
 
 import { useState } from "react";
-import { jwtDecode } from "jwt-decode";
-import { useRouter } from "next/navigation";
-
-interface JwtPayload {
-  role: string;
-  exp: number;
-  iat: number;
-}
+import { useAuth } from "@/hooks/useAuth";
 
 export default function Login() {
-  const router = useRouter();
+  const { login } = useAuth();
   const [creds, setCreds] = useState({ email: "", password: "" });
   const [error, setError] = useState("");
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
-    const res = await fetch("/api/auth/token/", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(creds),
-    });
-    if (res.ok) {
-      const data = await res.json();
-      localStorage.setItem("access", data.access);
-      localStorage.setItem("refresh", data.refresh);
-      try {
-        const { role } = jwtDecode<JwtPayload>(data.access);
-        if (role === "EMPLOYER") {
-          router.push("/employer/dashboard");
-        } else {
-          router.push("/dashboard");
-        }
-      } catch {
-        router.push("/dashboard");
-      }
-    } else {
-      const text = await res.text();
-      try {
-        const data = JSON.parse(text);
-        setError(JSON.stringify(data));
-      } catch {
-        setError(text);   // plain HTML or string
-      }
+    try {
+      await login(creds);
+    } catch (err) {
+      setError((err as Error).message);
     }
   }
 


### PR DESCRIPTION
## Summary
- use the existing `useAuth` hook inside the login page

## Testing
- `npx next lint`
- `npx tsc --noEmit`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_685adeb6fe348331803fdc415441afcf