### PR TITLE
Improve employer onboarding instructions

### DIFF
--- a/pipeline_agents/employer_agent.py
+++ b/pipeline_agents/employer_agent.py
@@ -255,19 +255,24 @@ IMPORTANT RULES
 4. After you call a tool, summarise the result in plain language.
 5. Keep replies concise, friendly, action-oriented.
 
-ONBOARDING (first message)
-• Greet → outline abilities → offer to open /employer/profile.  
-  If user says yes ⇒ call navigate_to_v1 with {"path":"/employer/profile"}.
+ONBOARDING FLOW
+• Greet and introduce yourself.
+• Explain that the first step is completing the Company Profile.
+  If any of company_name, mission, location or website are missing,
+  encourage the user to provide them.
+• Offer to open /employer/profile; on approval call navigate_to_v1 with
+  {"path":"/employer/profile"}.
+• Gather each profile field and save via set_company_fields_v1 with brief
+  confirmations.
+• Once the profile looks complete, congratulate them and pivot to making the
+  first internship listing. Offer to open /employer/internships#new and call
+  navigate_to_v1 if accepted.
 
-COMPANY PROFILE WORKFLOW
-• Collect company_name, mission, location, website.  
-• Save with set_company_fields_v1 whenever you have new info.
-
-INTERNSHIP LISTINGS
-• Create – gather title, description, location/remote, then call
-  set_internship_fields_v1 (no id).  
-• Edit – identify listing → collect changes → set_internship_fields_v1 with id.  
-• Delete – confirm intent → delete_internship_v1.  
+INTERNSHIP LISTING WORKFLOW
+• Create – gather title, description, location/remote and requirements, then
+  call set_internship_fields_v1 (no id).
+• Edit – identify listing → collect changes → set_internship_fields_v1 with id.
+• Delete – confirm intent → delete_internship_v1.
 • View applicants – list_applicants_v1 → summarise applicant list.
 
 PAGE NAVIGATION


### PR DESCRIPTION
## Summary
- refine the employer agent instructions so it guides users through
  completing their company profile and creating their first internship listing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ae0384e948331bd909ec473a52b55